### PR TITLE
Allow files to be passed as parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.*.swp
+example

--- a/README.md
+++ b/README.md
@@ -3,3 +3,17 @@
 This script aims to make charting lyrics in Clone Hero charts easier. Instead of directly adding lyric events, 
 notes can be placed temporarily in an unused chart, then converted using this script into lyric, phrase_start, 
 and phrase_end events. This makes it easier to visualise, or hear the lyric timing in editors like Moonscraper.
+
+## Usage
+
+	./keystolyrics.py <chart in> <chart out>
+
+This usage will read a script in from the first file, and output to the second file, overwriting an existing file if neccessary.
+
+	./keystolyrics.py <chart>
+
+This usage will modify the chart in place. And create a backup appended with `.bak`.
+
+	./keystolyrics.py
+
+This usage will read a chart file in from stdin and output to stdout.

--- a/keystolyrics.py
+++ b/keystolyrics.py
@@ -156,6 +156,8 @@ if __name__ == "__main__":
 	input_path = getattr(args, "input-file")
 	output_path = getattr(args, "output-file")
 
+	files_closable = False
+
 	if input_path is None:
 		# No files specified, use stdin and stdout
 		file_in = sys.stdin
@@ -170,10 +172,16 @@ if __name__ == "__main__":
 
 		file_in = open(input_path)
 		file_out = open(output_path, "w")
+		files_closable = True
 	
 	else:
 		# Two files specified, use those locations
-		# TODO: this
-		sys.exit(69)
+		file_in = open(input_path)
+		file_out = open(output_path, "w")
+		files_closable = True
 
 	convert_chart(file_in, file_out)
+
+	if files_closable:
+		file_in.close()
+		file_out.close()

--- a/keystolyrics.py
+++ b/keystolyrics.py
@@ -24,7 +24,6 @@ Expected notes.chart format:
 }
 """
 
-import sys
 import re
 from operator import attrgetter
 
@@ -36,26 +35,26 @@ class ChartEvent:
 	def get_code(self):
 		return '  {} = E "{}"'.format(self.time, self.name)
 
-def main():
+def main(file_in, file_out):
 	# Echo stuff before events
 	while True:
-		line = sys.stdin.readline()
+		line = file_in.readline()
 		if line == "":
 			raise Exception("Chart has no Events Section")
 		
 		if re.match(r"\[Events\]\s*", line):
 			break
 		
-		sys.stdout.write(line)
+		file_out.write(line)
 	
 	# Read in current events
-	open_brace_line = sys.stdin.readline()
+	open_brace_line = file_in.readline()
 	if not re.match(r"\{\s*", open_brace_line):
 		raise Exception('Line after "[Events]" should contain only "{"')
 	
 	global_events = []
 	while True:
-		line = sys.stdin.readline()
+		line = file_in.readline()
 		if line == "":
 			raise Exception("Unexpected EOF during events section")
 		event_match = re.match(r'\s*(\d+)\s*=\s*E\s*"([^"]*)"\s*', line)
@@ -71,7 +70,7 @@ def main():
 	# Read and store diffs before ExpertKeyboard
 	diff_text = ""
 	while True:
-		line = sys.stdin.readline()
+		line = file_in.readline()
 		if line == "":
 			raise Exception("File has no ExpertKeyboard chart to convert")
 		
@@ -82,12 +81,12 @@ def main():
 	
 	# when we find ExpertKeyboard:
 	# read in the notes, converting them to lyric events
-	open_brace_line = sys.stdin.readline()
+	open_brace_line = file_in.readline()
 	if not re.match(r"\{\s*", open_brace_line):
 		raise Exception('Line after "[ExpertKeyboard]" should contain only "{"')
 	
 	while True:
-		line = sys.stdin.readline()
+		line = file_in.readline()
 		if line == "":
 			raise Exception("Unexpected EOF during ExpertKeyboard chart")
 		
@@ -124,7 +123,7 @@ def main():
 	
 	# Read and store any diffs after ExpertKeyboard
 	while True:
-		line = sys.stdin.readline()
+		line = file_in.readline()
 		if line == "":
 			break
 		
@@ -134,14 +133,14 @@ def main():
 	global_events = sorted(global_events, key=attrgetter("time"))
 	
 	# Print the events section
-	print("[Events]")
-	print("{")
+	file_out.write("[Events]\n{\n")
 	for event in global_events:
-		print(event.get_code())
-	print("}")
+		file_out.write(event.get_code() + "\n")
+	file_out.write("}\n")
 	
 	# Print previously stored diffs
-	sys.stdout.write(diff_text)
+	file_out.write(diff_text)
 
 if __name__ == "__main__":
-	main()
+	import sys
+	main(sys.stdin, sys.stdout)

--- a/keystolyrics.py
+++ b/keystolyrics.py
@@ -157,6 +157,7 @@ if __name__ == "__main__":
 	output_path = getattr(args, "output-file")
 
 	files_closable = False
+	created_backup = False
 
 	if input_path is None:
 		# No files specified, use stdin and stdout
@@ -169,6 +170,7 @@ if __name__ == "__main__":
 		input_path += ".bak"
 
 		shutil.move(output_path, input_path)
+		created_backup = True
 
 		file_in = open(input_path)
 		file_out = open(output_path, "w")
@@ -180,8 +182,19 @@ if __name__ == "__main__":
 		file_out = open(output_path, "w")
 		files_closable = True
 
-	convert_chart(file_in, file_out)
+	try:
+		convert_chart(file_in, file_out)
+		err = None
+	except Exception as e:
+		err = e
 
 	if files_closable:
 		file_in.close()
 		file_out.close()
+
+	# On error, restore backup and re-raise
+	if err:
+		if created_backup:
+			shutil.move(input_path, output_path)
+
+		raise err

--- a/keystolyrics.py
+++ b/keystolyrics.py
@@ -35,7 +35,7 @@ class ChartEvent:
 	def get_code(self):
 		return '  {} = E "{}"'.format(self.time, self.name)
 
-def main(file_in, file_out):
+def convert_chart(file_in, file_out):
 	# Echo stuff before events
 	while True:
 		line = file_in.readline()
@@ -143,4 +143,37 @@ def main(file_in, file_out):
 
 if __name__ == "__main__":
 	import sys
-	main(sys.stdin, sys.stdout)
+	import shutil
+	from argparse import ArgumentParser
+
+	parser = ArgumentParser(description="Convert notes to lyric events in a Clone Hero chart")
+
+	parser.add_argument("input-file", nargs="?", help="Input chart location")
+	parser.add_argument("output-file", nargs="?", help="Output chart location")
+
+	args = parser.parse_args()
+
+	input_path = getattr(args, "input-file")
+	output_path = getattr(args, "output-file")
+
+	if input_path is None:
+		# No files specified, use stdin and stdout
+		file_in = sys.stdin
+		file_out = sys.stdout
+	
+	elif output_path is None:
+		# One file specified, move to .bak, write to original location
+		output_path = input_path
+		input_path += ".bak"
+
+		shutil.move(output_path, input_path)
+
+		file_in = open(input_path)
+		file_out = open(output_path, "w")
+	
+	else:
+		# Two files specified, use those locations
+		# TODO: this
+		sys.exit(69)
+
+	convert_chart(file_in, file_out)

--- a/keystolyrics.py
+++ b/keystolyrics.py
@@ -143,6 +143,7 @@ def convert_chart(file_in, file_out):
 
 if __name__ == "__main__":
 	import sys
+	import os
 	import shutil
 	from argparse import ArgumentParser
 
@@ -187,14 +188,15 @@ if __name__ == "__main__":
 		err = None
 	except Exception as e:
 		err = e
+	finally:
+		if files_closable:
+			file_in.close()
+			file_out.close()
 
-	if files_closable:
-		file_in.close()
-		file_out.close()
+		if err:
+			os.remove(output_path)
 
-	# On error, restore backup and re-raise
-	if err:
-		if created_backup:
-			shutil.move(input_path, output_path)
+			if created_backup:
+				shutil.move(input_path, output_path)
 
-		raise err
+			raise err


### PR DESCRIPTION
Allows zero, one, or two filenames to be passed into the script to specify input and output files.

Closes #1

- Input and output files passed to main as args
- Read chart location in as arg
- Added .gitignore
- Allow two files locations to be passed
- Add usage information to the readme
- Restore backup on error
- Delete output file on error
